### PR TITLE
Corrected national BioPlugin version service to v8

### DIFF
--- a/mongo.js
+++ b/mongo.js
@@ -409,7 +409,7 @@ var ilr_client = {
           "secured": false,
           "host": "$FINGERPRINT_HOST",
           "port": 80,
-          "path": "/M2Sys.BioPluginWeb/BioPluginService.asmx",
+          "path": "/M2Sys.BioPluginWeb/BioPluginServiceV8.asmx",
           "pathTransform": "",
           "primary": true,
           "username": "",


### PR DESCRIPTION
Corrected national BioPlugin version to v8 (same as local). The previous one didn't work correctly - different message were returned. The corrected one works properly -> configured one server to be local and national. For both types of queries the response is correct.